### PR TITLE
Add Comment API Routes

### DIFF
--- a/api/models/comment.py
+++ b/api/models/comment.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import Column, ForeignKey, Integer, String, UUID
+from sqlalchemy import UUID, Column, ForeignKey, Integer, String
 from sqlmodel import Field, Relationship, SQLModel
 
 if TYPE_CHECKING:

--- a/api/routers/comments.py
+++ b/api/routers/comments.py
@@ -48,6 +48,4 @@ async def delete_comment(comment_id: int, comments_repository: CommentsRepositor
     if existing_comment.user_id != user.id:
         raise HTTPException(status_code=403, detail="Not authorized to delete this comment")
 
-    success = await comments_repository.delete_comment(comment_id)
-    if not success:
-        raise HTTPException(status_code=404, detail="Comment not found")
+    await comments_repository.delete_comment(comment_id)

--- a/api/routers/comments.py
+++ b/api/routers/comments.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, HTTPException
+
+from api.models.comment import Comment
+from api.setup.dependencies import CommentsRepositoryDep, CurrentUserDep
+
+router = APIRouter()
+
+
+@router.get("", response_model=list[Comment], tags=["comments"])
+async def list_comments(comments_repository: CommentsRepositoryDep) -> list[Comment]:
+    comments = await comments_repository.all_comments()
+    return list(comments)
+
+
+@router.get("/{comment_id}", response_model=Comment, tags=["comments"])
+async def find_comment(comment_id: int, comments_repository: CommentsRepositoryDep) -> Comment:
+    comment = await comments_repository.find_comment(comment_id)
+    if not comment:
+        raise HTTPException(status_code=404, detail="Comment not found")
+    return comment
+
+
+@router.post("", response_model=Comment, status_code=201, tags=["comments"])
+async def create_comment(comment: Comment, comments_repository: CommentsRepositoryDep, user: CurrentUserDep) -> Comment:
+    comment.user_id = user.id
+    return await comments_repository.create_comment(comment)
+
+
+@router.put("/{comment_id}", response_model=Comment, tags=["comments"])
+async def update_comment(
+    comment_id: int, comment: Comment, comments_repository: CommentsRepositoryDep, _user: CurrentUserDep
+) -> Comment:
+    updated_comment = await comments_repository.update_comment(comment_id, comment)
+    if not updated_comment:
+        raise HTTPException(status_code=404, detail="Comment not found")
+    return updated_comment
+
+
+@router.delete("/{comment_id}", status_code=204, tags=["comments"])
+async def delete_comment(comment_id: int, comments_repository: CommentsRepositoryDep, _user: CurrentUserDep):
+    success = await comments_repository.delete_comment(comment_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Comment not found")

--- a/api/setup/app.py
+++ b/api/setup/app.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from api.routers import auth, posts
+from api.routers import auth, comments, posts
 from api.setup.database import create_db_and_tables
 
 
@@ -34,6 +34,7 @@ app.add_middleware(
 
 # Include routers
 app.include_router(posts.router, prefix="/api/v1/posts", tags=["posts"])
+app.include_router(comments.router, prefix="/api/v1/comments", tags=["comments"])
 app.include_router(auth.router, prefix="/auth", tags=["authentication"])
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ filterwarnings = [
 
 [dependency-groups]
 dev = [
+    "basedpyright>=1.31.6",
     "pytest-mock>=3.15.1",
     "ruff>=0.13.1",
 ]

--- a/tests/routers/test_comments_router.py
+++ b/tests/routers/test_comments_router.py
@@ -1,0 +1,394 @@
+# pyright: reportUnknownVariableType=false
+# pyright: reportMissingParameterType=false
+# pyright: reportUnknownParameterType=false
+# pyright: reportUnknownArgumentType=false
+# pyright: reportAny=false
+# pyright: reportUnknownMemberType=false
+
+import uuid
+from unittest.mock import create_autospec
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+
+from api.models.comment import Comment
+from api.models.user import User
+from api.services.repositories.comments_repository import CommentsRepository
+from api.setup.app import app
+from api.setup.auth import current_user
+from api.setup.dependencies import get_comments_repository
+
+
+@pytest.fixture
+def test_engine():
+    """Create a test database engine"""
+    return create_engine("sqlite:///:memory:")
+
+
+@pytest.fixture
+def test_session(test_engine):
+    """Create a test database session"""
+    SQLModel.metadata.create_all(test_engine)
+    with Session(test_engine) as session:
+        yield session
+
+
+@pytest.fixture
+def mock_comments_repository() -> CommentsRepository:
+    mock: CommentsRepository = create_autospec(CommentsRepository, spec_set=True, instance=True)
+    return mock
+
+
+@pytest.fixture
+def mock_current_user():
+    """Create a mock current user"""
+    user = User(
+        id=uuid.UUID("123e4567-e89b-12d3-a456-426614174000"),
+        email="test@example.com",
+        hashed_password="hashed_password",
+        is_active=True,
+    )
+    return user
+
+
+@pytest.fixture
+def client_with_mocks(mock_comments_repository, mock_current_user):
+    """Create a test client with mocked dependencies"""
+
+    def override_get_comments_repository():
+        return mock_comments_repository
+
+    def override_current_user():
+        return mock_current_user
+
+    app.dependency_overrides[get_comments_repository] = override_get_comments_repository
+    app.dependency_overrides[current_user] = override_current_user
+
+    with TestClient(app) as client:
+        yield client, mock_comments_repository, mock_current_user
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def sample_comment():
+    """Create a sample comment for testing"""
+    return Comment(id=1, body="Test comment", is_published=True, post_id=1)
+
+
+@pytest.fixture
+def sample_comments():
+    """Create a list of sample comments for testing"""
+    return [
+        Comment(id=1, body="First comment", is_published=True, post_id=1),
+        Comment(id=2, body="Second comment", is_published=True, post_id=1),
+        Comment(id=3, body="Third comment", is_published=True, post_id=2),
+    ]
+
+
+class TestListComments:
+    """Test cases for GET /api/v1/comments endpoint"""
+
+    @pytest.mark.asyncio
+    async def test_list_comments_success(self, client_with_mocks, sample_comments):
+        """Test successful retrieval of all comments"""
+        client, mock_repo, _ = client_with_mocks
+        mock_repo.all_comments.return_value = sample_comments
+
+        response = client.get("/api/v1/comments")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 3
+        assert data[0]["body"] == "First comment"
+        assert data[1]["body"] == "Second comment"
+        assert data[2]["body"] == "Third comment"
+        mock_repo.all_comments.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_list_comments_empty(self, client_with_mocks):
+        """Test retrieval when no comments exist"""
+        client, mock_repo, _ = client_with_mocks
+        mock_repo.all_comments.return_value = []
+
+        response = client.get("/api/v1/comments")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 0
+        mock_repo.all_comments.assert_called_once()
+
+
+class TestFindComment:
+    """Test cases for GET /api/v1/comments/{comment_id} endpoint"""
+
+    @pytest.mark.asyncio
+    async def test_find_comment_success(self, client_with_mocks, sample_comment):
+        """Test successful retrieval of a specific comment"""
+        client, mock_repo, _ = client_with_mocks
+        mock_repo.find_comment.return_value = sample_comment
+
+        response = client.get("/api/v1/comments/1")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == 1
+        assert data["body"] == "Test comment"
+        mock_repo.find_comment.assert_called_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_find_comment_not_found(self, client_with_mocks):
+        """Test retrieval of non-existent comment"""
+        client, mock_repo, _ = client_with_mocks
+        mock_repo.find_comment.return_value = None
+
+        response = client.get("/api/v1/comments/999")
+
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"] == "Comment not found"
+        mock_repo.find_comment.assert_called_once_with(999)
+
+    @pytest.mark.asyncio
+    async def test_find_comment_invalid_id(self, client_with_mocks):
+        """Test retrieval with invalid comment ID format"""
+        client, _, _ = client_with_mocks
+
+        response = client.get("/api/v1/comments/invalid")
+
+        assert response.status_code == 422  # Validation error
+
+
+class TestCreateComment:
+    """Test cases for POST /api/v1/comments endpoint"""
+
+    @pytest.mark.asyncio
+    async def test_create_comment_success(self, client_with_mocks, sample_comment):
+        """Test successful comment creation"""
+        client, mock_repo, _ = client_with_mocks
+        mock_repo.create_comment.return_value = sample_comment
+
+        comment_data = {"body": "Test comment", "is_published": True, "post_id": 1}
+        response = client.post("/api/v1/comments", json=comment_data)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["id"] == 1
+        assert data["body"] == "Test comment"
+        # Verify the call was made with a Comment object
+        mock_repo.create_comment.assert_called_once()
+        call_args = mock_repo.create_comment.call_args[0][0]
+        assert call_args.body == "Test comment"
+
+    @pytest.mark.asyncio
+    async def test_create_comment_with_id_specified(self, client_with_mocks):
+        """Test comment creation when ID is specified (should be ignored)"""
+        client, mock_repo, _ = client_with_mocks
+
+        created_comment = Comment(id=1, body="Test comment", is_published=True, post_id=1)
+        mock_repo.create_comment.return_value = created_comment
+
+        comment_data = {"id": 999, "body": "Test comment", "is_published": True, "post_id": 1}  # ID should be ignored
+        response = client.post("/api/v1/comments", json=comment_data)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["id"] == 1  # Uses the ID from mock, not from request
+        assert data["body"] == "Test comment"
+        mock_repo.create_comment.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_comment_empty_body(self, client_with_mocks):
+        """Test comment creation with empty body"""
+        client, mock_repo, _ = client_with_mocks
+
+        created_comment = Comment(id=1, body="", is_published=False, post_id=1)
+        mock_repo.create_comment.return_value = created_comment
+
+        comment_data = {"body": "", "is_published": False, "post_id": 1}
+        response = client.post("/api/v1/comments", json=comment_data)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["body"] == ""
+        mock_repo.create_comment.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_comment_without_auth(self):
+        """Test comment creation without authentication"""
+        with TestClient(app) as client:
+            comment_data = {"body": "Test comment", "is_published": True, "post_id": 1}
+            response = client.post("/api/v1/comments", json=comment_data)
+
+            assert response.status_code == 401
+
+
+class TestUpdateComment:
+    """Test cases for PUT /api/v1/comments/{comment_id} endpoint"""
+
+    @pytest.mark.asyncio
+    async def test_update_comment_success(self, client_with_mocks):
+        """Test successful comment update"""
+        client, mock_repo, _ = client_with_mocks
+        updated_comment = Comment(id=1, body="Updated comment", is_published=True, post_id=1)
+        mock_repo.update_comment.return_value = updated_comment
+
+        comment_data = {"body": "Updated comment", "is_published": True, "post_id": 1}
+        response = client.put("/api/v1/comments/1", json=comment_data)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == 1
+        assert data["body"] == "Updated comment"
+        # Verify the call was made correctly
+        mock_repo.update_comment.assert_called_once()
+        call_args = mock_repo.update_comment.call_args
+        assert call_args[0][0] == 1  # comment_id
+        assert call_args[0][1].body == "Updated comment"  # updated comment data
+
+    @pytest.mark.asyncio
+    async def test_update_comment_not_found(self, client_with_mocks):
+        """Test update of non-existent comment"""
+        client, mock_repo, _ = client_with_mocks
+        mock_repo.update_comment.return_value = None
+
+        comment_data = {"body": "Updated comment", "is_published": True, "post_id": 1}
+        response = client.put("/api/v1/comments/999", json=comment_data)
+
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"] == "Comment not found"
+        mock_repo.update_comment.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_comment_with_same_body(self, client_with_mocks):
+        """Test update with same body"""
+        client, mock_repo, _ = client_with_mocks
+
+        updated_comment = Comment(id=1, body="Same body", is_published=True, post_id=1)
+        mock_repo.update_comment.return_value = updated_comment
+
+        comment_data = {"body": "Same body", "is_published": True, "post_id": 1}
+        response = client.put("/api/v1/comments/1", json=comment_data)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == 1
+        assert data["body"] == "Same body"
+        mock_repo.update_comment.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_comment_without_auth(self):
+        """Test comment update without authentication"""
+        with TestClient(app) as client:
+            comment_data = {"body": "Updated comment", "is_published": True, "post_id": 1}
+            response = client.put("/api/v1/comments/1", json=comment_data)
+
+            assert response.status_code == 401
+
+
+class TestDeleteComment:
+    """Test cases for DELETE /api/v1/comments/{comment_id} endpoint"""
+
+    @pytest.mark.asyncio
+    async def test_delete_comment_success(self, client_with_mocks):
+        """Test successful comment deletion"""
+        client, mock_repo, _ = client_with_mocks
+        mock_repo.delete_comment.return_value = True
+
+        response = client.delete("/api/v1/comments/1")
+
+        assert response.status_code == 204
+        assert response.text == ""
+        mock_repo.delete_comment.assert_called_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_delete_comment_not_found(self, client_with_mocks):
+        """Test deletion of non-existent comment"""
+        client, mock_repo, _ = client_with_mocks
+        mock_repo.delete_comment.return_value = False
+
+        response = client.delete("/api/v1/comments/999")
+
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"] == "Comment not found"
+        mock_repo.delete_comment.assert_called_once_with(999)
+
+    @pytest.mark.asyncio
+    async def test_delete_comment_invalid_id(self, client_with_mocks):
+        """Test deletion with invalid comment ID format"""
+        client, _, _ = client_with_mocks
+
+        response = client.delete("/api/v1/comments/invalid")
+
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_delete_comment_without_auth(self):
+        """Test comment deletion without authentication"""
+        with TestClient(app) as client:
+            response = client.delete("/api/v1/comments/1")
+
+            assert response.status_code == 401
+
+
+class TestCommentsControllerIntegration:
+    """Integration test cases for comments controller"""
+
+    @pytest.mark.asyncio
+    async def test_full_comment_lifecycle(self, client_with_mocks):
+        """Test complete CRUD lifecycle of a comment"""
+        client, mock_repo, _ = client_with_mocks
+
+        # Create
+        created_comment = Comment(id=1, body="Test comment", is_published=True, post_id=1)
+        mock_repo.create_comment.return_value = created_comment
+
+        create_response = client.post(
+            "/api/v1/comments", json={"body": "Test comment", "is_published": True, "post_id": 1}
+        )
+        assert create_response.status_code == 201
+
+        # Read
+        mock_repo.find_comment.return_value = created_comment
+        get_response = client.get("/api/v1/comments/1")
+        assert get_response.status_code == 200
+        get_data = get_response.json()
+        assert get_data["body"] == "Test comment"
+
+        # Update
+        updated_comment = Comment(id=1, body="Updated comment", is_published=True, post_id=1)
+        mock_repo.update_comment.return_value = updated_comment
+
+        update_response = client.put(
+            "/api/v1/comments/1", json={"body": "Updated comment", "is_published": True, "post_id": 1}
+        )
+        assert update_response.status_code == 200
+        update_data = update_response.json()
+        assert update_data["body"] == "Updated comment"
+
+        # Delete
+        mock_repo.delete_comment.return_value = True
+        delete_response = client.delete("/api/v1/comments/1")
+        assert delete_response.status_code == 204
+
+    @pytest.mark.asyncio
+    async def test_comments_controller_with_multiple_comments(self, client_with_mocks, sample_comments):
+        """Test controller with multiple comments in different scenarios"""
+        client, mock_repo, _ = client_with_mocks
+
+        # Test listing multiple comments
+        mock_repo.all_comments.return_value = sample_comments
+        response = client.get("/api/v1/comments")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 3
+
+        # Test finding specific comments
+        mock_repo.find_comment.return_value = sample_comments[0]
+        response = client.get("/api/v1/comments/1")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["body"] == "First comment"

--- a/uv.lock
+++ b/uv.lock
@@ -132,6 +132,18 @@ wheels = [
 ]
 
 [[package]]
+name = "basedpyright"
+version = "1.31.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodejs-wheel-binaries" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/f6/c5657b1e464d04757cde2db76922a88091fe16854bd3d12e470c23b0dcf1/basedpyright-1.31.6.tar.gz", hash = "sha256:07f3602ba1582218dfd1db25b8b69cd3493e1f4367f46a44fd57bb9034b52ea9", size = 22683901, upload-time = "2025-10-01T13:11:21.317Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/2b/34f338b4c04fe965fd209ed872d9fdd893dacc1a06feb6c9fec13ff535c1/basedpyright-1.31.6-py3-none-any.whl", hash = "sha256:620968ee69c14eee6682f29ffd6f813a30966afb1083ecfa4caf155c5d24f2d5", size = 11805295, upload-time = "2025-10-01T13:11:18.308Z" },
+]
+
+[[package]]
 name = "bcrypt"
 version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -446,6 +458,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "basedpyright" },
     { name = "pytest-mock" },
     { name = "ruff" },
 ]
@@ -467,6 +480,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "basedpyright", specifier = ">=1.31.6" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "ruff", specifier = ">=0.13.1" },
 ]
@@ -788,6 +802,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "nodejs-wheel-binaries"
+version = "22.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/54/02f58c8119e2f1984e2572cc77a7b469dbaf4f8d171ad376e305749ef48e/nodejs_wheel_binaries-22.20.0.tar.gz", hash = "sha256:a62d47c9fd9c32191dff65bbe60261504f26992a0a19fe8b4d523256a84bd351", size = 8058, upload-time = "2025-09-26T09:48:00.906Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/6d/333e5458422f12318e3c3e6e7f194353aa68b0d633217c7e89833427ca01/nodejs_wheel_binaries-22.20.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:455add5ac4f01c9c830ab6771dbfad0fdf373f9b040d3aabe8cca9b6c56654fb", size = 53246314, upload-time = "2025-09-26T09:47:32.536Z" },
+    { url = "https://files.pythonhosted.org/packages/56/30/dcd6879d286a35b3c4c8f9e5e0e1bcf4f9e25fe35310fc77ecf97f915a23/nodejs_wheel_binaries-22.20.0-py2.py3-none-macosx_11_0_x86_64.whl", hash = "sha256:5d8c12f97eea7028b34a84446eb5ca81829d0c428dfb4e647e09ac617f4e21fa", size = 53644391, upload-time = "2025-09-26T09:47:36.093Z" },
+    { url = "https://files.pythonhosted.org/packages/58/be/c7b2e7aa3bb281d380a1c531f84d0ccfe225832dfc3bed1ca171753b9630/nodejs_wheel_binaries-22.20.0-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a2b0989194148f66e9295d8f11bc463bde02cbe276517f4d20a310fb84780ae", size = 60282516, upload-time = "2025-09-26T09:47:39.88Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c5/8befacf4190e03babbae54cb0809fb1a76e1600ec3967ab8ee9f8fc85b65/nodejs_wheel_binaries-22.20.0-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b5c500aa4dc046333ecb0a80f183e069e5c30ce637f1c1a37166b2c0b642dc21", size = 60347290, upload-time = "2025-09-26T09:47:43.712Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/bd/cfffd1e334277afa0714962c6ec432b5fe339340a6bca2e5fa8e678e7590/nodejs_wheel_binaries-22.20.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3279eb1b99521f0d20a850bbfc0159a658e0e85b843b3cf31b090d7da9f10dfc", size = 62178798, upload-time = "2025-09-26T09:47:47.752Z" },
+    { url = "https://files.pythonhosted.org/packages/08/14/10b83a9c02faac985b3e9f5e65d63a34fc0f46b48d8a2c3e4caa3e1e7318/nodejs_wheel_binaries-22.20.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d29705797b33bade62d79d8f106c2453c8a26442a9b2a5576610c0f7e7c351ed", size = 62772957, upload-time = "2025-09-26T09:47:51.266Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a9/c6a480259aa0d6b270aac2c6ba73a97444b9267adde983a5b7e34f17e45a/nodejs_wheel_binaries-22.20.0-py2.py3-none-win_amd64.whl", hash = "sha256:4bd658962f24958503541963e5a6f2cc512a8cb301e48a69dc03c879f40a28ae", size = 40120431, upload-time = "2025-09-26T09:47:54.363Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b1/6a4eb2c6e9efa028074b0001b61008c9d202b6b46caee9e5d1b18c088216/nodejs_wheel_binaries-22.20.0-py2.py3-none-win_arm64.whl", hash = "sha256:1fccac931faa210d22b6962bcdbc99269d16221d831b9a118bbb80fe434a60b8", size = 38844133, upload-time = "2025-09-26T09:47:57.357Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Implements Comment API routes with full CRUD operations following the established pattern from posts router.

## Changes
- Created `api/routers/comments.py` with GET/POST/PUT/DELETE endpoints
- Routes use Comment model directly (no separate schemas)
- Slim router pattern delegating to CommentsRepository
- Authentication required for create/update/delete operations
- Registered router at `/api/v1/comments` in main application
- Added comprehensive integration tests in `tests/routers/test_comments_router.py` (19 test cases)
- Fixed User fixture to include `hashed_password` for type checking
- Added basedpyright as dev dependency

## Test Plan
- [x] All 19 new comment router tests passing
- [x] Full test suite passing (74 tests total)
- [x] Ruff linter passing
- [x] basedpyright type checker passing

## Acceptance Criteria
- [x] GET/POST/PUT/DELETE endpoints using Comment model directly (no separate schemas)
- [x] Routes follow slim pattern (delegate to repository)
- [x] Proper authentication/authorization (require authenticated user)
- [x] Integration tests in `tests/routers/test_comments_router.py`
- [x] Router registered in main application

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)